### PR TITLE
Support for linux/amd64 and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 # snakeqr Makefile
 
-CC =		cc
+CC =		clang
 CFLAGS =	-Oz -nostdinc -ffreestanding
-CFLAGS +=	-fno-PIE -fno-PIC -fno-ret-protector -fomit-frame-pointer
+CFLAGS +=	-fno-PIE -fno-PIC -fomit-frame-pointer
 CFLAGS +=	-fno-stack-protector -mno-retpoline
-CFLAGS +=	-Wno-int-to-void-pointer-cast
 
 PROG =	snakeqr
 OBJS =	crt.o snakeqr.o
@@ -13,6 +12,8 @@ all: ${OBJS}
 	/usr/bin/ld -nopie -o ${PROG} ${OBJS}
 	/usr/bin/strip ${PROG}
 	/usr/bin/strip -R .comment ${PROG}
+
+compress:
 	/usr/bin/gzexe ${PROG}
 
 qr:

--- a/crt.S
+++ b/crt.S
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifndef __linux__
 	.section ".note.openbsd.ident", "a"
 	.p2align 2
 	.long	0x8
@@ -42,3 +43,56 @@ _syscall:
 	syscall
 	retq
 	.size	_syscall,.-_syscall
+
+#else
+#ifdef __amd64__
+
+.globl _start
+.globl _syscall
+
+.text
+_start:
+	call    main
+	mov     $60, %rax
+	xor     %rdi, %rdi
+	syscall
+
+_syscall:
+	test    %al, %al
+	mov     %rdi, %rax
+	mov     %rsi, %rdi
+	mov     %rdx, %rsi
+	mov     %rcx, %rdx
+	mov     %r8, %r10
+	mov     %r9, %r8
+	je done
+	pop     %r9
+done:
+	syscall
+	ret
+
+#elif defined(__aarch64__)
+
+.globl _start
+.globl _syscall
+
+.text
+_start:
+	bl      main
+	mov     x0, #0
+	mov     w8, #93
+	svc     #0
+
+_syscall:
+	mov     x8, x0
+	mov     x0, x1
+	mov     x1, x2
+	mov     x2, x3
+	mov     x3, x4
+	mov     x4, x5
+	mov     x5, x6
+	svc     #0
+	ret
+
+#endif // __aarch64__
+#endif // __linux__

--- a/snakeqr.c
+++ b/snakeqr.c
@@ -117,7 +117,7 @@ struct sigaction {
 
 #else
 struct sigaction {
-    void (*sa_handler)(int);
+	void (*sa_handler)(int);
 	unsigned long sa_flags;
 	void (*sa_restorer) (void);
 	unsigned long sa_mask;
@@ -168,7 +168,7 @@ sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
 #ifndef __linux__
 	_syscall(SYS_SIGACTION, sig, act, oact);
 #else
-    _syscall(SYS_RT_SIGACTION, sig, act, oact, 8);  // sigactsize = sizeof(sigset_t)
+	_syscall(SYS_RT_SIGACTION, sig, act, oact, 8);  // sigactsize = sizeof(sigset_t)
 #endif // __linux__
 }
 
@@ -176,7 +176,7 @@ sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
 static void
 sigreturn(void)
 {
-    _syscall(SYS_RT_SIGRETURN);
+	_syscall(SYS_RT_SIGRETURN);
 }
 #endif // __linux__ && __amd64__
 


### PR DESCRIPTION
I littered your code with preprocessor directives to make it a bit more portable and added syscall numbers for amd64 and arm64.
Besides, _syscall now takes variadic arguments, silencing compiler warnings and also seemingly reducing binary size by a few bytes.

So far, tested on:
- linux 5.9 (amd64)
- linux 5.4 (arm64, actually a raspberry pi)
- OpenBSD virtual machine

Also, it should now be straightforward to support more architectures by adding another syscall table and the corresponding assembly code in crt.S