### PR TITLE
fix compile error on clang13 && add details in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Here it is.
 This QR code is the compiled binary.
 The entire ELF executable clocks in at just under 2 KB (2024 bytes, to be exact).
 
+Directions
+---------
+h: left
+j: down
+k: up
+l: right
+
 Why?
 ----
 Read my


### PR DESCRIPTION
about the error `error: unable to disambiguate: -nopie (did you mean --nopie ?)` :

I try to move `-nopie` to CFLAGS, and then it works. Though the volume seems to be bigger.

```
❯ ls -al snakeqr
.rwxr-xr-x w users 8.5 KB Mon Jan 24 00:43:13 2022  snakeqr
❯ file snakeqr
snakeqr: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```
